### PR TITLE
Fix header y cositas

### DIFF
--- a/estilos.css
+++ b/estilos.css
@@ -17,6 +17,7 @@ a {
 
  /* header */
 header {
+    z-index: 90;
     width: 100%;
 }
 
@@ -94,6 +95,7 @@ ul{
 }
 
 .desplegable {
+    z-index: 99;
     background-color: #DDDDDD;
     border-radius: 0px 0px 23px 23px;
 }

--- a/estilos.css
+++ b/estilos.css
@@ -11,6 +11,10 @@ body {
     cursor: url(img/cursor.png), auto;
 }
 
+main {
+    padding-top: 80px;
+}
+
 a {
     cursor: url(img/cursor-click.png), auto;
 }
@@ -18,6 +22,8 @@ a {
  /* header */
 header {
     z-index: 90;
+    position: fixed;
+    height: 80px;
     width: 100%;
 }
 


### PR DESCRIPTION
Buenas! Acá el ayudante fantasma de Compu3!

Les dejo dos commits porque me contaron que necesitaban una mano para hacer andar el desplegable en el index, y para dejar fijo el header.

- Para el tema del desplegable, la solución fue agregarle `z-index` tanto al `header` como al `desplegable`. Esta propiedad sirve para ordenar cosas en "profundidad". El error que estaban teniendo, en index, era que las imagenes esas que cambian solas se estaban interponiendo con el desplegable. Poniendole un `z-index` alto al desplegable lo "traemos al frente".

No es conveniente agregar z-index por todos lados, cuantos menos tengan mejor, pero a veces ayuda para "desempatar" cuando tienen este tipo de cosas que se superponen entre si.

- Para la posición `fixed`, solamente le agregué la propiedad al header entero y funciona, **pero** hay dos cosas que necesitamos agregar para que se siga viendo bien:
    - A partir de que tiene `position: fixed`, deja de ocupar espacio, entonces todo lo demas se mueve para arriba. Necesitamos agregarle un padding al primer contenido que aparece (en su caso `body`) para volver a rellenar ese espacio.
    - Como necesitamos que el espacio de relleno para el header y su altura sean iguales, se agrega la `height:80px` que es igual al `padding-top: 80px` del contenido.
    - Por qué `80px`? Cuando lo levanté, esa es la altura que tenía hoy. **Si necesitan cambiarlo, solo no se olviden de cambiarlo en los dos lugares**
    
- Un último detalle, descargando su repo noté que tienen varios videos en calidad 1080p. Esto puede ser algo pesado para descargar tanto en las máquinas suyas como en la web. Si pueden comprimirlos con su programa de edición de video favorito, o bajarles la resolución, sería un lujo

Espero les sirva y cualquier cosa le avisan a Aimé y lo revisamos.
Saludos!